### PR TITLE
Add simulator inside the shopping-cart-service

### DIFF
--- a/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
+++ b/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
@@ -34,6 +34,11 @@ object ShoppingCartEventConsumer {
     private var throughputStartTime = System.nanoTime()
     private var throughputCount = 0
 
+    private var lagCount = 0L
+    // JVM System property
+    private val lagThresholdMillis =
+      Integer.getInteger("ShoppingCartEventConsumer.lag-threshold-ms", 2000)
+
     override def start(): Future[Done] = {
       log.info("Started Projection [{}].", projectionId.id)
       super.start()
@@ -52,7 +57,7 @@ object ShoppingCartEventConsumer {
 
       event match {
         case itemAdded: ItemAdded =>
-          log.info(
+          log.debug(
             "Projection [{}] consumed ItemAdded for cart {}, added {} {}. Total [{}] events.",
             projectionId.id,
             itemAdded.cartId,
@@ -60,7 +65,7 @@ object ShoppingCartEventConsumer {
             itemAdded.itemId,
             totalCount)
         case quantityAdjusted: ItemQuantityAdjusted =>
-          log.info(
+          log.debug(
             "Projection [{}] consumed ItemQuantityAdjusted for cart {}, changed {} {}. Total [{}] events.",
             projectionId.id,
             quantityAdjusted.cartId,
@@ -68,14 +73,14 @@ object ShoppingCartEventConsumer {
             quantityAdjusted.itemId,
             totalCount)
         case itemRemoved: ItemRemoved =>
-          log.info(
+          log.debug(
             "Projection [{}] consumed ItemRemoved for cart {}, removed {}. Total [{}] events.",
             projectionId.id,
             itemRemoved.cartId,
             itemRemoved.itemId,
             totalCount)
         case checkedOut: CheckedOut =>
-          log.info(
+          log.debug(
             "Projection [{}] consumed CheckedOut for cart {}. Total [{}] events.",
             projectionId.id,
             checkedOut.cartId,
@@ -89,21 +94,28 @@ object ShoppingCartEventConsumer {
         (System.nanoTime - throughputStartTime) / 1000 / 1000
       if (throughputCount >= 1000 || durationMs >= 10000) {
         log.info(
-          "Projection [{}] throughput [{}] events/s in [{}] ms",
+          "Projection [{}] throughput [{}] events/s in [{}] ms. Total [{}] events.",
           projectionId.id,
           1000L * throughputCount / durationMs,
-          durationMs)
+          durationMs,
+          totalCount)
         throughputCount = 0
         throughputStartTime = System.nanoTime
       }
 
-      val projectionLag: Long = System.currentTimeMillis() - envelope.timestamp
-      if(projectionLag > 2000) {
-        log.info(
-          "Projection [{}] lag greater than 2 seconds is [{}] ms",
-          projectionId.id,
-          projectionLag)
+      val lagMillis = System.currentTimeMillis() - envelope.timestamp
+      if (lagMillis > lagThresholdMillis) {
+        lagCount += 1
+        if ((lagCount == 1) || (lagCount % 1000 == 0))
+          log.info(
+            "Projection [{}] lag [{}] ms. Total [{}] events.",
+            projectionId.id,
+            lagMillis,
+            totalCount)
+      } else {
+        lagCount = 0
       }
+
       Future.successful(Done)
     }
   }

--- a/samples/grpc/shopping-cart-service-scala/k8s/deployment.yaml
+++ b/samples/grpc/shopping-cart-service-scala/k8s/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75 -Dshopping-cart-service.grpc.port=8080 -Dakka.persistence.r2dbc.connection-factory.host=10.8.205.4 -Dakka.persistence.r2dbc.connection-factory.ssl.enabled=on -Dakka.persistence.r2dbc.connection-factory.ssl.mode=require"
+              value: "-XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75 -Dshopping-cart-service.grpc.port=8080 -Dakka.persistence.r2dbc.connection-factory.host=10.8.205.4 -Dakka.persistence.r2dbc.connection-factory.ssl.enabled=on -Dakka.persistence.r2dbc.connection-factory.ssl.mode=require -Dshopping-cart-service.simulator-count=10 -Dshopping-cart-service.simulator-delay=200ms"
             - name: REQUIRED_CONTACT_POINT_NR
               value: "1"
             - name: DB_HOST

--- a/samples/grpc/shopping-cart-service-scala/src/main/java/shopping/cart/Simulator.java
+++ b/samples/grpc/shopping-cart-service-scala/src/main/java/shopping/cart/Simulator.java
@@ -1,0 +1,115 @@
+package shopping.cart;
+
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.AbstractBehavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Receive;
+import akka.actor.typed.javadsl.TimerScheduler;
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.EntityRef;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Simulator extends AbstractBehavior<Simulator.Command> {
+ // Defining this here because mixing java and Scala
+ private static final EntityTypeKey<ShoppingCart.Command> ENTITY_KEY =
+     EntityTypeKey.create(ShoppingCart.Command.class, ShoppingCart.EntityKey().name());
+
+ interface Command extends CborSerializable {
+ }
+
+ public static final class NextCart implements Simulator.Command {
+  public NextCart() {
+  }
+ }
+
+ public static final class Next implements Simulator.Command {
+  public final int n;
+
+  public Next(int n) {
+   this.n = n;
+  }
+ }
+
+ public static final class Delay implements Simulator.Command {
+  public Delay() {
+  }
+ }
+
+ public static Behavior<Void> createMany() {
+  return Behaviors.setup(ctx -> {
+       int n = ctx.getSystem().settings().config().getInt("shopping-cart-service.simulator-count");
+       for (int i = 0; i < n; i++) {
+        ctx.spawn(create(), "simulator-" + i);
+       }
+       return Behaviors.empty();
+      }
+  );
+ }
+
+ public static Behavior<Simulator.Command> create() {
+  return Behaviors.setup(ctx ->
+      Behaviors.withTimers(timers ->
+          new Simulator(ctx, timers)));
+ }
+
+ private final TimerScheduler<Command> timers;
+ private final ClusterSharding sharding;
+ private final Duration timeout;
+ private final Duration delay;
+
+ private String cart = "";
+
+ public Simulator(ActorContext<Command> ctx, TimerScheduler<Command> timers) {
+  super(ctx);
+  this.timers = timers;
+  sharding = ClusterSharding.get(ctx.getSystem());
+  timeout = ctx.getSystem().settings().config().getDuration("shopping-cart-service.ask-timeout");
+  delay = ctx.getSystem().settings().config().getDuration("shopping-cart-service.simulator-delay");
+
+  ctx.setReceiveTimeout(Duration.ofSeconds(10), new NextCart());
+  timers.startSingleTimer(new NextCart(), Duration.ofMillis(5000));
+ }
+
+ @Override
+ public Receive<Command> createReceive() {
+  return newReceiveBuilder()
+      .onMessage(Delay.class, this::onDelay)
+      .onMessage(NextCart.class, this::onNextCart)
+      .onMessage(Next.class, this::onNext)
+      .build();
+ }
+
+ private Behavior<Command> onDelay(Delay d) {
+  timers.startSingleTimer(new NextCart(), delay);
+  return this;
+ }
+
+ private Behavior<Command> onNextCart(NextCart next) {
+  cart = UUID.randomUUID().toString();
+  EntityRef<ShoppingCart.Command> ref = sharding.entityRefFor(ENTITY_KEY, cart);
+  getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout, replyTo -> new ShoppingCart.AddItem("t-shirt", 1, replyTo), (summary, exc) -> new Next(1));
+  return this;
+ }
+
+ private Behavior<Command> onNext(Next next) {
+  EntityRef<ShoppingCart.Command> ref = sharding.entityRefFor(ENTITY_KEY, cart);
+
+  if (next.n <= 5) {
+   getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout,
+       replyTo -> new ShoppingCart.AdjustItemQuantity("t-shirt", next.n + 1, replyTo),
+       (summary, exc) -> new Next(next.n + 1));
+  } else {
+   getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout,
+       ShoppingCart.Checkout::new,
+       (summary, exc) -> new Delay());
+  }
+
+  return this;
+ }
+
+}

--- a/samples/grpc/shopping-cart-service-scala/src/main/resources/application.conf
+++ b/samples/grpc/shopping-cart-service-scala/src/main/resources/application.conf
@@ -15,4 +15,6 @@ akka.projection.grpc {
 
 shopping-cart-service {
   ask-timeout = 5 s
+  simulator-count = 0
+  simulator-delay = 100ms
 }

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -1,6 +1,5 @@
 package shopping.cart
 
-import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.ActorSystem
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
@@ -13,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val system =
-      ActorSystem[Nothing](Behaviors.empty, "ShoppingCartService")
+      ActorSystem(Simulator.createMany(), "ShoppingCartService")
     try {
       init(system)
     } catch {
@@ -36,7 +35,12 @@ object Main {
     val grpcPort =
       system.settings.config.getInt("shopping-cart-service.grpc.port")
     val grpcService = new ShoppingCartServiceImpl(system)
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService, eventProducerService)
+    ShoppingCartServer.start(
+      grpcInterface,
+      grpcPort,
+      system,
+      grpcService,
+      eventProducerService)
   }
 
 }


### PR DESCRIPTION
Included the same simulator as I used in my previous tests. One less moving part (and we don't have to worry about that the incoming grpc is the bottleneck).

A few comments inline....