### PR TITLE
Add simulator inside the shopping-cart-service (Kafka branch)

### DIFF
--- a/samples/grpc/shopping-cart-service-scala/k8s/deployment.yaml
+++ b/samples/grpc/shopping-cart-service-scala/k8s/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75 -Dshopping-cart-service.grpc.port=8080 -Dakka.persistence.r2dbc.connection-factory.host=10.8.205.4 -Dakka.persistence.r2dbc.connection-factory.ssl.enabled=on -Dakka.persistence.r2dbc.connection-factory.ssl.mode=require"
+              value: "-XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75 -Dshopping-cart-service.grpc.port=8080 -Dakka.persistence.r2dbc.connection-factory.host=10.8.205.4 -Dakka.persistence.r2dbc.connection-factory.ssl.enabled=on -Dakka.persistence.r2dbc.connection-factory.ssl.mode=require -Dshopping-cart-service.simulator-count=10 -Dshopping-cart-service.simulator-delay=200ms"
             - name: REQUIRED_CONTACT_POINT_NR
               value: "1"
             - name: DB_HOST

--- a/samples/grpc/shopping-cart-service-scala/src/main/java/shopping/cart/Simulator.java
+++ b/samples/grpc/shopping-cart-service-scala/src/main/java/shopping/cart/Simulator.java
@@ -1,0 +1,115 @@
+package shopping.cart;
+
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.AbstractBehavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Receive;
+import akka.actor.typed.javadsl.TimerScheduler;
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.EntityRef;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Simulator extends AbstractBehavior<Simulator.Command> {
+ // Defining this here because mixing java and Scala
+ private static final EntityTypeKey<ShoppingCart.Command> ENTITY_KEY =
+     EntityTypeKey.create(ShoppingCart.Command.class, ShoppingCart.EntityKey().name());
+
+ interface Command extends CborSerializable {
+ }
+
+ public static final class NextCart implements Simulator.Command {
+  public NextCart() {
+  }
+ }
+
+ public static final class Next implements Simulator.Command {
+  public final int n;
+
+  public Next(int n) {
+   this.n = n;
+  }
+ }
+
+ public static final class Delay implements Simulator.Command {
+  public Delay() {
+  }
+ }
+
+ public static Behavior<Void> createMany() {
+  return Behaviors.setup(ctx -> {
+       int n = ctx.getSystem().settings().config().getInt("shopping-cart-service.simulator-count");
+       for (int i = 0; i < n; i++) {
+        ctx.spawn(create(), "simulator-" + i);
+       }
+       return Behaviors.empty();
+      }
+  );
+ }
+
+ public static Behavior<Simulator.Command> create() {
+  return Behaviors.setup(ctx ->
+      Behaviors.withTimers(timers ->
+          new Simulator(ctx, timers)));
+ }
+
+ private final TimerScheduler<Command> timers;
+ private final ClusterSharding sharding;
+ private final Duration timeout;
+ private final Duration delay;
+
+ private String cart = "";
+
+ public Simulator(ActorContext<Command> ctx, TimerScheduler<Command> timers) {
+  super(ctx);
+  this.timers = timers;
+  sharding = ClusterSharding.get(ctx.getSystem());
+  timeout = ctx.getSystem().settings().config().getDuration("shopping-cart-service.ask-timeout");
+  delay = ctx.getSystem().settings().config().getDuration("shopping-cart-service.simulator-delay");
+
+  ctx.setReceiveTimeout(Duration.ofSeconds(10), new NextCart());
+  timers.startSingleTimer(new NextCart(), Duration.ofMillis(5000));
+ }
+
+ @Override
+ public Receive<Command> createReceive() {
+  return newReceiveBuilder()
+      .onMessage(Delay.class, this::onDelay)
+      .onMessage(NextCart.class, this::onNextCart)
+      .onMessage(Next.class, this::onNext)
+      .build();
+ }
+
+ private Behavior<Command> onDelay(Delay d) {
+  timers.startSingleTimer(new NextCart(), delay);
+  return this;
+ }
+
+ private Behavior<Command> onNextCart(NextCart next) {
+  cart = UUID.randomUUID().toString();
+  EntityRef<ShoppingCart.Command> ref = sharding.entityRefFor(ENTITY_KEY, cart);
+  getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout, replyTo -> new ShoppingCart.AddItem("t-shirt", 1, replyTo), (summary, exc) -> new Next(1));
+  return this;
+ }
+
+ private Behavior<Command> onNext(Next next) {
+  EntityRef<ShoppingCart.Command> ref = sharding.entityRefFor(ENTITY_KEY, cart);
+
+  if (next.n <= 5) {
+   getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout,
+       replyTo -> new ShoppingCart.AdjustItemQuantity("t-shirt", next.n + 1, replyTo),
+       (summary, exc) -> new Next(next.n + 1));
+  } else {
+   getContext().askWithStatus(ShoppingCart.Summary.class, ref, timeout,
+       ShoppingCart.Checkout::new,
+       (summary, exc) -> new Delay());
+  }
+
+  return this;
+ }
+
+}

--- a/samples/grpc/shopping-cart-service-scala/src/main/resources/application.conf
+++ b/samples/grpc/shopping-cart-service-scala/src/main/resources/application.conf
@@ -16,4 +16,6 @@ akka.projection.grpc {
 
 shopping-cart-service {
   ask-timeout = 5 s
+  simulator-count = 0
+  simulator-delay = 100ms
 }

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -1,6 +1,5 @@
 package shopping.cart
 
-import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.ActorSystem
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
@@ -13,7 +12,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val system =
-      ActorSystem[Nothing](Behaviors.empty, "ShoppingCartService")
+      ActorSystem(Simulator.createMany(), "ShoppingCartService")
     try {
       init(system)
     } catch {
@@ -37,7 +36,12 @@ object Main {
     val grpcPort =
       system.settings.config.getInt("shopping-cart-service.grpc.port")
     val grpcService = new ShoppingCartServiceImpl(system)
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService, eventProducerService)
+    ShoppingCartServer.start(
+      grpcInterface,
+      grpcPort,
+      system,
+      grpcService,
+      eventProducerService)
   }
 
 }

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishKafkaEventsProjection.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishKafkaEventsProjection.scala
@@ -7,13 +7,16 @@ import akka.cluster.sharding.typed.scaladsl.ShardedDaemonProcess
 import akka.kafka.ProducerSettings
 import akka.kafka.scaladsl.SendProducer
 import akka.persistence.query.Offset
+import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.r2dbc.query.javadsl.R2dbcReadJournal
-import akka.projection.eventsourced.EventEnvelope
 import akka.projection.eventsourced.scaladsl.EventSourcedProvider
 import akka.projection.r2dbc.scaladsl.R2dbcProjection
-import akka.projection.scaladsl.{AtLeastOnceProjection, SourceProvider}
-import akka.projection.{ProjectionBehavior, ProjectionId}
-import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import akka.projection.scaladsl.{ AtLeastOnceProjection, SourceProvider }
+import akka.projection.{ ProjectionBehavior, ProjectionId }
+import org.apache.kafka.common.serialization.{
+  ByteArraySerializer,
+  StringSerializer
+}
 
 object PublishKafkaEventsProjection {
 
@@ -22,12 +25,18 @@ object PublishKafkaEventsProjection {
     val topic =
       system.settings.config.getString("shopping-cart-service.kafka.topic")
 
+    val numberOfSliceRanges: Int = 4
+    val sliceRanges = EventSourcedProvider.sliceRanges(
+      system,
+      R2dbcReadJournal.Identifier,
+      numberOfSliceRanges)
+
     ShardedDaemonProcess(system).init(
       name = "PublishEventsProjection",
-      ShoppingCart.tags.size,
+      numberOfInstances = sliceRanges.size,
       index =>
         ProjectionBehavior(
-          createProjectionFor(system, topic, sendProducer, index)),
+          createProjectionFor(system, topic, sendProducer, sliceRanges(index))),
       ShardedDaemonProcessSettings(system),
       Some(ProjectionBehavior.Stop))
   }
@@ -50,22 +59,29 @@ object PublishKafkaEventsProjection {
       system: ActorSystem[_],
       topic: String,
       sendProducer: SendProducer[String, Array[Byte]],
-      index: Int)
+      sliceRange: Range)
       : AtLeastOnceProjection[Offset, EventEnvelope[ShoppingCart.Event]] = {
-    val tag = ShoppingCart.tags(index)
+    val minSlice = sliceRange.min
+    val maxSlice = sliceRange.max
+    val projectionId =
+      ProjectionId("PublishEventsProjection", s"carts-$minSlice-$maxSlice")
+
     val sourceProvider
         : SourceProvider[Offset, EventEnvelope[ShoppingCart.Event]] =
-      EventSourcedProvider.eventsByTag[ShoppingCart.Event](
+      EventSourcedProvider.eventsBySlices[ShoppingCart.Event](
         system = system,
         readJournalPluginId = R2dbcReadJournal.Identifier,
-        tag = tag)
+        ShoppingCart.EntityKey.name,
+        minSlice,
+        maxSlice)
 
     R2dbcProjection.atLeastOnceAsync(
-      projectionId = ProjectionId("PublishEventsProjection", tag),
+      projectionId,
       None,
       sourceProvider,
-      handler =
-        () => new PublishKafkaEventsProjectionHandler(system, topic, sendProducer))(system)
+      handler = () =>
+        new PublishKafkaEventsProjectionHandler(system, topic, sendProducer))(
+      system)
   }
 
 }

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishKafkaEventsProjectionHandler.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishKafkaEventsProjectionHandler.scala
@@ -1,21 +1,20 @@
-
 package shopping.cart
 
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.kafka.scaladsl.SendProducer
-import akka.projection.eventsourced.EventEnvelope
 import akka.projection.scaladsl.Handler
-import com.google.protobuf.any.{Any => ScalaPBAny}
+import com.google.protobuf.any.{ Any => ScalaPBAny }
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
+import scala.concurrent.{ ExecutionContext, Future }
 
-import scala.concurrent.{ExecutionContext, Future}
+import akka.persistence.query.typed.EventEnvelope
 
 class PublishKafkaEventsProjectionHandler(
     system: ActorSystem[_],
     topic: String,
-    sendProducer: SendProducer[String, Array[Byte]]) 
+    sendProducer: SendProducer[String, Array[Byte]])
     extends Handler[EventEnvelope[ShoppingCart.Event]] {
   private val log = LoggerFactory.getLogger(getClass)
   private implicit val ec: ExecutionContext =
@@ -28,7 +27,7 @@ class PublishKafkaEventsProjectionHandler(
     // using the cartId as the key and `DefaultPartitioner` will select partition based on the key
     // so that events for same cart always ends up in same partition
     val key = event.cartId
-    val producerRecord = new ProducerRecord(topic, key, serialize(event)) 
+    val producerRecord = new ProducerRecord(topic, key, serialize(event))
     val result = sendProducer.send(producerRecord).map { recordMetadata =>
       log.info(
         "Published event [{}] to topic/partition {}/{}",
@@ -44,17 +43,16 @@ class PublishKafkaEventsProjectionHandler(
     val protoMessage = event match {
       case ShoppingCart.ItemAdded(cartId, itemId, quantity) =>
         proto.ItemAdded(cartId, itemId, quantity)
-      
+
       case ShoppingCart.ItemQuantityAdjusted(cartId, itemId, quantity, _) =>
         proto.ItemQuantityAdjusted(cartId, itemId, quantity)
       case ShoppingCart.ItemRemoved(cartId, itemId, _) =>
         proto.ItemRemoved(cartId, itemId)
-      
+
       case ShoppingCart.CheckedOut(cartId, _) =>
         proto.CheckedOut(cartId)
     }
     // pack in Any so that type information is included for deserialization
-    ScalaPBAny.pack(protoMessage, "shopping-cart-service").toByteArray 
+    ScalaPBAny.pack(protoMessage, "shopping-cart-service").toByteArray
   }
 }
-

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala
@@ -147,11 +147,9 @@ object ShoppingCart {
   val EntityKey: EntityTypeKey[Command] =
     EntityTypeKey[Command]("ShoppingCart")
 
-  val tags = Vector.tabulate(5)(i => s"carts-$i")
-
   def init(system: ActorSystem[_]): Unit = {
-    ClusterSharding(system).init(
-      Entity(EntityKey)(entityContext => ShoppingCart(entityContext.entityId)))
+    ClusterSharding(system).init(Entity(EntityKey)(entityContext =>
+      ShoppingCart(entityContext.entityId)))
   }
 
   def apply(cartId: String): Behavior[Command] = {


### PR DESCRIPTION
This is the same as https://github.com/ceecer1/akka-projection/pull/2, but for the Kafka branch.
On top of https://github.com/ceecer1/akka-projection/pull/1, which should be merged first.