### PR TITLE
Wrong sliceRange min/max caused overlapping projections

### DIFF
--- a/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
+++ b/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
@@ -126,15 +126,15 @@ object ShoppingCartEventConsumer {
       { idx =>
         val sliceRange = sliceRanges(idx)
         val projectionKey =
-          s"${eventsBySlicesQuery.streamId}-${sliceRange.start}-${sliceRange.end}"
+          s"${eventsBySlicesQuery.streamId}-${sliceRange.min}-${sliceRange.max}"
         val projectionId = ProjectionId.of(projectionName, projectionKey)
 
         val sourceProvider = EventSourcedProvider.eventsBySlices[AnyRef](
           system,
           eventsBySlicesQuery,
           eventsBySlicesQuery.streamId,
-          sliceRange.start,
-          sliceRange.end)
+          sliceRange.min,
+          sliceRange.max)
 
         ProjectionBehavior(
           R2dbcProjection.atLeastOnceAsync(


### PR DESCRIPTION
and thereby unique constraint violations

This will ofc also be changed in upstream samples.