### PR TITLE
Wrong sliceRange min/max caused overlapping projections (Kafka)

### DIFF
--- a/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
+++ b/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
@@ -126,15 +126,15 @@ object ShoppingCartEventConsumer {
       { idx =>
         val sliceRange = sliceRanges(idx)
         val projectionKey =
-          s"${eventsBySlicesQuery.streamId}-${sliceRange.start}-${sliceRange.end}"
+          s"${eventsBySlicesQuery.streamId}-${sliceRange.min}-${sliceRange.max}"
         val projectionId = ProjectionId.of(projectionName, projectionKey)
 
         val sourceProvider = EventSourcedProvider.eventsBySlices[AnyRef](
           system,
           eventsBySlicesQuery,
           eventsBySlicesQuery.streamId,
-          sliceRange.start,
-          sliceRange.end)
+          sliceRange.min,
+          sliceRange.max)
 
         ProjectionBehavior(
           R2dbcProjection.atLeastOnceAsync(


### PR DESCRIPTION
and thereby unique constraint violations

(cherry picked from commit b7c23cb3cb34e4623fc3a5c89fea28598f485b00)

Same as https://github.com/ceecer1/akka-projection/pull/4 but for the Kafka branch